### PR TITLE
Replace deprecated 3-arg Base.rtoldefault with 1-arg form

### DIFF
--- a/src/comp.jl
+++ b/src/comp.jl
@@ -83,9 +83,9 @@ Base.isequal(p::Polynomial{V, M}, q::Polynomial{V, M}) where {V, M} = _compare(p
 function Base.isapprox(
     p::Polynomial{V,M,S},
     q::Polynomial{V,M,T};
-    rtol::Real = Base.rtoldefault(S, T, 0),
+    rtol::Real = Base.rtoldefault(real(promote_type(S, T))),
     atol::Real = 0,
-    ztol::Real = iszero(atol) ? Base.rtoldefault(S, T, 0) : atol,
+    ztol::Real = iszero(atol) ? Base.rtoldefault(real(promote_type(S, T))) : atol,
 ) where {V,M,S,T}
     i = j = 1
     while i <= length(p.x) || j <= length(q.x)


### PR DESCRIPTION
## Summary
- Replace `Base.rtoldefault(S, T, 0)` with `Base.rtoldefault(real(promote_type(S, T)))` in `Base.isapprox` for `Polynomial`

The 3-argument form of `rtoldefault` is deprecated in Julia pre-release, causing CI failures with `depwarn=error`.

## Test plan
- [ ] CI passes on julia-pre

https://claude.ai/code/session_01SGAgzkbRVNAL51y3Fo9fni