### PR TITLE
Fix StackOverflowError in promote_type with Any (#94, #166)

### DIFF
--- a/src/promote.jl
+++ b/src/promote.jl
@@ -60,8 +60,8 @@ function MP.promote_rule_constant(
 ) where {S,V,M,T}
     return Polynomial{V,M,promote_type(S, T)}
 end
-MP.promote_rule_constant(::Type, ::Type{_Term{V,M}}) where {V,M} = Any
-MP.promote_rule_constant(::Type, ::Type{Polynomial{V,M}}) where {V,M} = Any
+MP.promote_rule_constant(::Type, ::Type{_Term{V,M}}) where {V,M} = Union{}
+MP.promote_rule_constant(::Type, ::Type{Polynomial{V,M}}) where {V,M} = Union{}
 function Base.promote_rule(
     ::Type{_Term{V,M}},
     ::Type{_Term{V,M,T}},


### PR DESCRIPTION
## Summary
- Return `Union{}` instead of `Any` from `promote_rule_constant` when the coefficient type is unspecified (lines 63-64 of `src/promote.jl`)

Returning `Any` causes infinite recursion in `Base.promote_type` because `promote_rule` returns `Any` from one direction and the polynomial type from the other — this is the root cause of #94 and #166.

This surfaces on Julia 1.13-beta3 because the `@test` macro now evaluates function arguments individually ([JuliaLang/julia#57825](https://github.com/JuliaLang/julia/issues/57825)), creating `Expr`-typed values that trigger type promotion with polynomial types.

The remaining julia-pre CI failures are in MultivariatePolynomials' test/commutative/comparison.jl where `eval_test_function` creates `Expr` values that hit `MethodError: no method matching zero(::Expr)` — that needs to be fixed upstream in MP.

## Test plan
- [ ] CI passes on Julia 1, 1.10, x86
- [ ] julia-pre StackOverflow is eliminated (remaining failures are upstream MP test issues)

https://claude.ai/code/session_01SGAgzkbRVNAL51y3Fo9fni