### PR TITLE
Remove Test as a dependancy, and set LTS as minimum version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,13 @@ MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StarAlgebras = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MultivariatePolynomials = "0.5.15"
 MutableArithmetics = "1.6.5"
 Reexport = "1"
 StarAlgebras = "0.3"
-julia = "1"
+julia = "1.10"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
I noticed Test being added when adding DynamicPolynomials.jl.

(Not really a major issue but was just a bit surprised!)